### PR TITLE
Add iOS OpenVPN statistics logging

### DIFF
--- a/apple/PacketTunnelProvider.h
+++ b/apple/PacketTunnelProvider.h
@@ -26,6 +26,8 @@
 
 @property(nonatomic, strong) OpenVPNReachability *vpnReachability;
 
+@property(nonatomic, strong) NSTimer *statsTimer;
+
 typedef void (^StartHandler)(NSError *_Nullable);
 typedef void (^StopHandler)(void);
 

--- a/apple/PacketTunnelProvider.m
+++ b/apple/PacketTunnelProvider.m
@@ -116,6 +116,7 @@
         self.startHandler(nil);
       }
       self.startHandler = nil;
+      [self startStatsLogging];
       break;
     case OpenVPNAdapterEventDisconnected:
       if (self.vpnReachability.isTracking) {
@@ -125,6 +126,7 @@
         self.stopHandler();
       }
       self.stopHandler = nil;
+      [self stopStatsLogging];
       break;
     case OpenVPNAdapterEventReconnecting:
       self.reasserting = true;
@@ -154,6 +156,31 @@
 - (void)openVPNAdapter:(OpenVPNAdapter *)openVPNAdapter handleLogMessage:(NSString *)logMessage {
   // Handle log messages
   NSLog(@"PacketTunnelProvider: openVPNAdapter: logMSg: %@", logMessage);
+}
+
+- (void)startStatsLogging {
+  if (!self.statsTimer) {
+    self.statsTimer =
+        [NSTimer scheduledTimerWithTimeInterval:2
+                                         target:self
+                                       selector:@selector(logStats)
+                                       userInfo:nil
+                                        repeats:YES];
+  }
+}
+
+- (void)stopStatsLogging {
+  if (self.statsTimer) {
+    [self.statsTimer invalidate];
+    self.statsTimer = nil;
+  }
+}
+
+- (void)logStats {
+  OpenVPNStatistics *stats = self.vpnAdapter.statistics;
+  NSLog(@"PacketTunnelProvider: bytes in %llu - bytes out %llu",
+        (unsigned long long)stats.bytesIn,
+        (unsigned long long)stats.bytesOut);
 }
 
 - (void)handleAppMessage:(NSData *)messageData completionHandler:(void (^)(NSData *))completionHandler {


### PR DESCRIPTION
## Summary
- log OpenVPN traffic stats when connected on iOS

## Testing
- `npm test` *(fails: Error: no test specified)*
