### PR TITLE
Add byte count logging on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,10 @@ export default App;
 
 For more, read the [API Reference](docs/Reference.md)
 
+Traffic metrics are written to the native logs every two seconds while
+connected. Check Logcat on Android or the Xcode console on iOS to see the byte
+counts.
+
 ## OpenVPN library
 
 The following items were used in this project

--- a/android/src/main/java/com/norcod/rnovpn/RNSimpleOpenvpnModule.java
+++ b/android/src/main/java/com/norcod/rnovpn/RNSimpleOpenvpnModule.java
@@ -68,7 +68,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @RequiresApi(api = Build.VERSION_CODES.N)
-public class RNSimpleOpenvpnModule extends ReactContextBaseJavaModule implements VpnStatus.StateListener {
+public class RNSimpleOpenvpnModule extends ReactContextBaseJavaModule
+    implements VpnStatus.StateListener, VpnStatus.ByteCountListener {
 
   private String TAG = RNSimpleOpenvpnModule.class.getSimpleName();
   private HashMap<String, Object> ovpnOptions;
@@ -128,6 +129,7 @@ public class RNSimpleOpenvpnModule extends ReactContextBaseJavaModule implements
     reactContext = context;
     reactContext.addActivityEventListener(mActivityEventListener);
     VpnStatus.addStateListener(this);
+    VpnStatus.addByteCountListener(this);
 
     Intent intent = new Intent(context, OpenVPNService.class);
     intent.setAction(OpenVPNService.START_SERVICE);
@@ -324,6 +326,12 @@ public class RNSimpleOpenvpnModule extends ReactContextBaseJavaModule implements
     params.putString("message", state);
     params.putString("level", level.toString());
     sendEvent("stateChanged", params);
+  }
+
+  @Override
+  public void updateByteCount(long in, long out, long diffIn, long diffOut) {
+    Log.d(TAG,
+        "bytes in " + in + " (" + diffIn + ") - bytes out " + out + " (" + diffOut + ")");
   }
 
   public void setConnectedVPN(String uuid) {}

--- a/apple/PacketTunnelProvider.h
+++ b/apple/PacketTunnelProvider.h
@@ -26,6 +26,8 @@
 
 @property(nonatomic, strong) OpenVPNReachability *vpnReachability;
 
+@property(nonatomic, strong) NSTimer *statsTimer;
+
 typedef void (^StartHandler)(NSError *_Nullable);
 typedef void (^StopHandler)(void);
 

--- a/apple/PacketTunnelProvider.m
+++ b/apple/PacketTunnelProvider.m
@@ -116,6 +116,7 @@
         self.startHandler(nil);
       }
       self.startHandler = nil;
+      [self startStatsLogging];
       break;
     case OpenVPNAdapterEventDisconnected:
       if (self.vpnReachability.isTracking) {
@@ -125,6 +126,7 @@
         self.stopHandler();
       }
       self.stopHandler = nil;
+      [self stopStatsLogging];
       break;
     case OpenVPNAdapterEventReconnecting:
       self.reasserting = true;
@@ -154,6 +156,31 @@
 - (void)openVPNAdapter:(OpenVPNAdapter *)openVPNAdapter handleLogMessage:(NSString *)logMessage {
   // Handle log messages
   NSLog(@"PacketTunnelProvider: openVPNAdapter: logMSg: %@", logMessage);
+}
+
+- (void)startStatsLogging {
+  if (!self.statsTimer) {
+    self.statsTimer =
+        [NSTimer scheduledTimerWithTimeInterval:2
+                                         target:self
+                                       selector:@selector(logStats)
+                                       userInfo:nil
+                                        repeats:YES];
+  }
+}
+
+- (void)stopStatsLogging {
+  if (self.statsTimer) {
+    [self.statsTimer invalidate];
+    self.statsTimer = nil;
+  }
+}
+
+- (void)logStats {
+  OpenVPNStatistics *stats = self.vpnAdapter.statistics;
+  NSLog(@"PacketTunnelProvider: bytes in %llu - bytes out %llu",
+        (unsigned long long)stats.bytesIn,
+        (unsigned long long)stats.bytesOut);
 }
 
 - (void)handleAppMessage:(NSData *)messageData completionHandler:(void (^)(NSData *))completionHandler {

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -138,6 +138,13 @@ interface VpnEventParams {
 }
 ```
 
+### Traffic metrics
+
+Both Android and iOS log byte count statistics every two seconds while a VPN
+connection is active. These logs show total bytes received and sent as well as
+the delta for each interval. Check the native logs (Logcat on Android or the
+Xcode console on iOS) to view these metrics.
+
 ## Attention
 
 ### `xxx.ovpn` configuration file


### PR DESCRIPTION
## Summary
- log periodic byte counts in `RNSimpleOpenvpnModule`
- document traffic metric logs in README and API reference

## Testing
- `npm test` *(fails: Error: no test specified)*